### PR TITLE
Change variation formula

### DIFF
--- a/R/stock.R
+++ b/R/stock.R
@@ -41,7 +41,7 @@ add_monthly_variation <- function(stock_data, start_date) {
     mutate(Month = lubridate::floor_date(as.Date(Date), "month")) %>%
     group_by(Month) %>%
     mutate(rank = rank(Date)) %>%
-    filter(rank == 1) %>%
+    filter(rank == max(rank)) %>%
     ungroup(Month) %>%
     mutate(Variation = (Close - lag(Close)) / lag(Close)) %>%
     filter(Date >= start_date) %>%


### PR DESCRIPTION
Closes #14 

Instead of using first day of the month as basis for variation computation, we rely on the last available date in a month. The last available date will be either the last working day of a month or the last working day we have a stock price (in case of the current month).